### PR TITLE
[feature] Use existing analysis options (configurable behavior)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ flutter test --coverage
 # Run the analysis and publish to the SonarQube server
 sonar-scanner
 ```
+
+### Use existing analysis options
+
+The plugin uses its own analysis options file.
+If `analysis_options.yaml` file already exists under the project root, it will be saved during the analysis and then restored to its initial state.
+
+To disable this behavior and use the existing`analysis_options.yaml` file instead, add the following line to `sonar-project.properties` file :
+
+```
+# Use existing options to perform dartanalyzer analysis
+sonar.dart.analysis.useExistingOptions=true
+```
 	
 ## Contributing
 

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/DartSensor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/DartSensor.java
@@ -39,6 +39,7 @@ public class DartSensor implements Sensor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DartSensor.class);
     private static final int EXECUTOR_TIMEOUT = 10000;
+    public static final String DART_ANALYSIS_USE_EXISTING_OPTIONS_KEY = "sonar.dart.analysis.useExistingOptions";
 
     @Override
     public void describe(SensorDescriptor sensorDescriptor) {

--- a/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/FlutterPlugin.java
+++ b/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/FlutterPlugin.java
@@ -32,7 +32,9 @@ import org.sonar.api.resources.Qualifiers;
 
 public class FlutterPlugin implements Plugin {
 
+    public static final String DART_CATEGORY = "Dart";
     public static final String FLUTTER_CATEGORY = "Flutter";
+    public static final String ANALYSIS_SUBCATEGORY = "Analysis";
     public static final String GENERAL_SUBCATEGORY = "General";
     public static final String TESTS_SUBCATEGORY = "Tests";
 
@@ -63,6 +65,16 @@ public class FlutterPlugin implements Plugin {
                         .onQualifiers(Qualifiers.MODULE, Qualifiers.PROJECT)
                         .category(FLUTTER_CATEGORY)
                         .subCategory(TESTS_SUBCATEGORY)
+                        .build());
+
+        context.addExtension(
+                PropertyDefinition.builder(DartSensor.DART_ANALYSIS_USE_EXISTING_OPTIONS_KEY)
+                        .name("Use existing analysis_options file")
+                        .description("The SonarQube plugin for Flutter / Dart uses its own analysis_options file, even if it exists under the project root. If you want to use the existing analysis_options file instead, set the value to true.")
+                        .onQualifiers(Qualifiers.MODULE, Qualifiers.PROJECT)
+                        .category(DART_CATEGORY)
+                        .subCategory(ANALYSIS_SUBCATEGORY)
+                        .defaultValue("false")
                         .build());
 
         // Tests


### PR DESCRIPTION
The plugin uses its own analysis options file, even if `analysis_options.yaml` file already exists under the project root.

This feature allow to make this behavior configurable through `sonar-project.properties` or SonarQube administration configuration (**General Settings/Dart/Analysis**)