### PR TITLE
Add missing Dart keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 #### Enhancements
 
-- None.
+- Add missing dart keywords `extension`, `on`, `mixin`
 
 #### Bug Fixes
 

--- a/dart-lang/src/main/resources/dart.keywords
+++ b/dart-lang/src/main/resources/dart.keywords
@@ -2,6 +2,7 @@ abstract
 as
 assert
 async
+async*
 await
 break
 case
@@ -35,6 +36,7 @@ null
 on
 operator
 part
+required
 rethrow
 return
 set
@@ -42,6 +44,7 @@ static
 super
 switch
 sync
+sync*
 this
 throw
 true
@@ -51,3 +54,4 @@ void
 while
 with
 yield
+yield*

--- a/dart-lang/src/main/resources/dart.keywords
+++ b/dart-lang/src/main/resources/dart.keywords
@@ -14,8 +14,9 @@ do$dynamic
 else
 enum
 export
-external
 extends
+extension
+external
 factory
 false
 final
@@ -28,8 +29,10 @@ import
 in
 is
 library
+mixin
 new
 null
+on
 operator
 part
 rethrow
@@ -48,4 +51,3 @@ void
 while
 with
 yield
-


### PR DESCRIPTION
I wonder if `yield*`, `async*` and `sync*` are also needed explicitly. Don't have a project where that is uses currently analyzed.