### PR TITLE
Allow reuse of an existing dartanalyzer report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 #### Enhancements
 
-- None.
+- Allow re-using an existing dartanalyzer report with `sonar.dart.analysis.reportPath`
 
 #### Bug Fixes
 

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/DartSensor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/DartSensor.java
@@ -45,6 +45,7 @@ public class DartSensor implements Sensor {
     private static final Logger LOGGER = LoggerFactory.getLogger(DartSensor.class);
     private static final int EXECUTOR_TIMEOUT = 10000;
 	public static final String DART_ANALYSIS_USE_EXISTING_OPTIONS_KEY = "sonar.dart.analysis.useExistingOptions";
+	public static final String DART_ANALYSIS_USE_EXISTING_REPORT_PATH_KEY = "sonar.dart.analysis.reportPath";
 
     @Override
     public void describe(SensorDescriptor sensorDescriptor) {

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/SourceLinesProvider.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/SourceLinesProvider.java
@@ -59,7 +59,7 @@ public class SourceLinesProvider {
             }
             sourceLines.add(new SourceLine(totalLines, count, global - count, global));
         } catch (final Throwable e) {
-            LOGGER.warn("Error occured reading file", e);
+            LOGGER.warn("Error occurred reading file", e);
         }
 
         return sourceLines.toArray(new SourceLine[0]);

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerSensor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerSensor.java
@@ -19,7 +19,6 @@
  */
 package fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer;
 
-import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import fr.insideapp.sonarqube.dart.lang.Dart;
 import fr.insideapp.sonarqube.dart.lang.DartSensor;
@@ -37,9 +36,11 @@ import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.batch.sensor.issue.internal.DefaultIssueLocation;
 import org.sonar.api.rule.RuleKey;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -47,242 +48,272 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DartAnalyzerSensor implements Sensor {
-	private static final Logger LOGGER = LoggerFactory.getLogger(DartAnalyzerSensor.class);
-	private static final String ANALYZER_COMMAND = System.getProperty("os.name").toUpperCase().contains("WINDOWS")
-			? "dartanalyzer.bat"
-			: "dartanalyzer";
-	private static final int ANALYZER_TIMEOUT = 10 * 60 * 1000;
-	private static final String ANALYSIS_OPTIONS_FILENAME = "analysis_options.yaml";
-	private static final String ANALYSIS_OPTIONS_FILE = "/fr/insideapp/sonarqube/dart/dartanalyzer/analysis_options.yaml";
-	private static final Integer PAGE_SIZE = 50;
-	private boolean useExistingAnalysisOptions;
-	
-	@Override
-	public void describe(SensorDescriptor sensorDescriptor) {
-		sensorDescriptor.onlyOnLanguage(Dart.KEY).name("dartanalyzer sensor").onlyOnFileType(Type.MAIN);
-	}
+    private static final Logger LOGGER = LoggerFactory.getLogger(DartAnalyzerSensor.class);
+    private static final String ANALYZER_COMMAND = System.getProperty("os.name").toUpperCase().contains("WINDOWS")
+            ? "dartanalyzer.bat"
+            : "dartanalyzer";
+    private static final int ANALYZER_TIMEOUT = 10 * 60 * 1000;
+    private static final String ANALYSIS_OPTIONS_FILENAME = "analysis_options.yaml";
+    private static final String ANALYSIS_OPTIONS_FILE = "/fr/insideapp/sonarqube/dart/dartanalyzer/analysis_options.yaml";
+    private static final Integer PAGE_SIZE = 50;
+    private boolean useExistingAnalysisOptions;
 
-	@Override
-	public void execute(SensorContext sensorContext) {
-		try {
-			verifyIfDartAnalyzerExists();
-			
-			selectOptionFileToUse(sensorContext);
+    @Override
+    public void describe(SensorDescriptor sensorDescriptor) {
+        sensorDescriptor.onlyOnLanguage(Dart.KEY).name("dartanalyzer sensor").onlyOnFileType(Type.MAIN);
+    }
 
-			recordIssues(sensorContext, buildIssues(getFilesWithAbsolutePath(sensorContext)));
+    @Override
+    public void execute(@Nonnull SensorContext sensorContext) {
+        try {
+            if (sensorContext.config().hasKey(DartSensor.DART_ANALYSIS_USE_EXISTING_REPORT_PATH_KEY)) {
+                executeWithExistingReport(sensorContext);
+            } else {
+                executeWithAnalyzer(sensorContext);
+            }
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
 
-		} catch (Exception e) {
-			LOGGER.error(e.getMessage(), e);
-		} finally {
-			if (!useExistingAnalysisOptions) {
-				restoreCurrentAnalysisOptionsFile(sensorContext);
-			}
-		}
-	}
-
-	private void selectOptionFileToUse(SensorContext sensorContext) throws IOException {
-		useExistingAnalysisOptions = getUseExistingAnalysisOptions(sensorContext);
-
-		// Usage of existing option is required but file is missing
-		// Or usage of existing option is not required
-		if ((useExistingAnalysisOptions && !this.existsAnalysisOptionsFile(sensorContext)) || !useExistingAnalysisOptions) {
-			useDefaultAnalysisOptionsFile(sensorContext);
-		}
-	}
-
-	private void useDefaultAnalysisOptionsFile(SensorContext sensorContext) throws IOException {
-		LOGGER.debug("Either {} option is not set to true or {} file does not exists, use default analysis options instead",
-				DartSensor.DART_ANALYSIS_USE_EXISTING_OPTIONS_KEY, ANALYSIS_OPTIONS_FILENAME);
-
-		useExistingAnalysisOptions = false;
-
-		this.saveCurrentAnalysisOptionsFile(sensorContext);
-		this.createAnalysisOptionsFile(sensorContext);
-	}
-
-	private Boolean getUseExistingAnalysisOptions(SensorContext sensorContext) {
-		return sensorContext.config().getBoolean(DartSensor.DART_ANALYSIS_USE_EXISTING_OPTIONS_KEY).orElse(false);
-	}
-
-	private List<DartAnalyzerReportIssue> buildIssues(List<String> filesWithAbsolutePath)
-			throws IOException {
-		Set<DartAnalyzerReportIssue> issues = new HashSet<>();
-
-		for (String paginatedFileBatch : getPaginatedFilesPaths(filesWithAbsolutePath)) {
-
-			LOGGER.debug("Current file batch: {}", paginatedFileBatch);
-
-			try {
-				String output = new ProcBuilder(ANALYZER_COMMAND)
-						.withArgs(paginatedFileBatch.split(" "))
-						.withTimeoutMillis(ANALYZER_TIMEOUT)
-						//.withExpectedExitStatuses(0, 1, 2, 3)
-						.ignoreExitStatus()
-						.run()
-						.getOutputString();
-
-				issues.addAll(new DartAnalyzerReportParser().parse(output));
-			} catch (Exception e) {
-				throw new IOException(e);
-			}
+    private void executeWithExistingReport(SensorContext sensorContext) throws IOException {
+        final String path = sensorContext.config().get(DartSensor.DART_ANALYSIS_USE_EXISTING_REPORT_PATH_KEY)
+                .orElseThrow(() -> new IllegalArgumentException(DartSensor.DART_ANALYSIS_USE_EXISTING_REPORT_PATH_KEY + " is miss-configured!"));
+        final File report = sensorContext.fileSystem().resolvePath(path);
+        LOGGER.info("Analysing report from " + report.getPath());
+        List<DartAnalyzerReportIssue> issues = buildIssuesFromFile(report);
+        recordIssues(sensorContext, issues);
+    }
 
 
-		}
-		LOGGER.debug("Found issues: {}", issues.size());
-		List<DartAnalyzerReportIssue> result = new ArrayList<>();
-		result.addAll(issues);
-		return result;
-	}
+    private void executeWithAnalyzer(SensorContext sensorContext) throws IOException {
+        try {
+            verifyIfDartAnalyzerExists();
+            selectOptionFileToUse(sensorContext);
+            LOGGER.info("Analysing with dartanalyzer");
+            final List<DartAnalyzerReportIssue> issues = buildIssues(getFilesWithAbsolutePath(sensorContext));
+            recordIssues(sensorContext, issues);
+        } finally {
+            if (!useExistingAnalysisOptions) {
+                restoreCurrentAnalysisOptionsFile(sensorContext);
+            }
+        }
+    }
 
-	private List<String> getPaginatedFilesPaths(List<String> filesWithAbsolutePath) {
-		List<String> paginated = new ArrayList<String>();
+    private void selectOptionFileToUse(SensorContext sensorContext) throws IOException {
+        useExistingAnalysisOptions = getUseExistingAnalysisOptions(sensorContext);
 
-		LOGGER.debug("Paging the files to execute the analyzer...");
+        // Usage of existing option is required but file is missing
+        // Or usage of existing option is not required
+        if (!useExistingAnalysisOptions || !this.existsAnalysisOptionsFile(sensorContext)) {
+            useDefaultAnalysisOptionsFile(sensorContext);
+        }
+    }
 
-		Integer pagingStart = 0;
-		Integer pagingRemainder = getPaginationRemainder(filesWithAbsolutePath);
-		Integer totalPages = getPaginationTotalPages(filesWithAbsolutePath, PAGE_SIZE, pagingRemainder);
+    private void useDefaultAnalysisOptionsFile(SensorContext sensorContext) throws IOException {
+        LOGGER.debug("Either {} option is not set to true or {} file does not exists, use default analysis options instead",
+                DartSensor.DART_ANALYSIS_USE_EXISTING_OPTIONS_KEY, ANALYSIS_OPTIONS_FILENAME);
 
-		for (int i = 0; i < totalPages; i++) {
-			LOGGER.debug("Current index: {}", i);
+        useExistingAnalysisOptions = false;
 
-			LOGGER.debug("Current paging start: {}", pagingStart);
+        this.saveCurrentAnalysisOptionsFile(sensorContext);
+        this.createAnalysisOptionsFile(sensorContext);
+    }
 
-			Integer pagingEnd = getPagingEnd(pagingStart, pagingRemainder, totalPages, i);
+    private Boolean getUseExistingAnalysisOptions(SensorContext sensorContext) {
+        return sensorContext.config().getBoolean(DartSensor.DART_ANALYSIS_USE_EXISTING_OPTIONS_KEY).orElse(false);
+    }
 
-			paginated.add(getFilesPathsSplitBySpace(filesWithAbsolutePath, pagingStart, pagingEnd));
+    private List<DartAnalyzerReportIssue> buildIssues(List<String> filesWithAbsolutePath)
+            throws IOException {
 
-			pagingStart += PAGE_SIZE;
-		}
-		return paginated;
-	}
+        for (String paginatedFileBatch : getPaginatedFilesPaths(filesWithAbsolutePath)) {
 
-	private Integer getPagingEnd(Integer pagingStart, Integer pagingRemainder, Integer totalPages, int i) {
-		Integer pagingEnd = pagingStart + PAGE_SIZE;
-		if (isLastPage(pagingRemainder, totalPages, i)) {
-			pagingEnd = pagingStart + pagingRemainder;
-		}
-		LOGGER.debug("Current paging end: {}", pagingEnd);
-		return pagingEnd;
-	}
+            LOGGER.debug("Current file batch: {}", paginatedFileBatch);
 
-	private String getFilesPathsSplitBySpace(List<String> filesWithAbsolutePath, Integer pagingStart,
-			Integer pagingEnd) {
-		return filesWithAbsolutePath.subList(pagingStart, pagingEnd).stream().collect(Collectors.joining(" "));
-	}
+            try {
+                String output = new ProcBuilder(ANALYZER_COMMAND)
+                        .withArgs(paginatedFileBatch.split(" "))
+                        .withTimeoutMillis(ANALYZER_TIMEOUT)
+                        //.withExpectedExitStatuses(0, 1, 2, 3)
+                        .ignoreExitStatus()
+                        .run()
+                        .getOutputString();
 
-	private boolean isLastPage(Integer pagingRemainder, Integer totalPages, int i) {
-		return pagingRemainder != 0 && i + 1 == totalPages;
-	}
+                return createIssuesFromOutput(output);
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        }
+        LOGGER.debug("Found no issues");
+        return new ArrayList<>();
+    }
 
-	private Integer getPaginationRemainder(List<String> filesWithAbsolutePath) {
-		Integer remainder = filesWithAbsolutePath.size() % PAGE_SIZE;
+    private List<DartAnalyzerReportIssue> buildIssuesFromFile(File report)
+            throws IOException {
+        if (report != null && report.exists() && report.canRead()) {
+            final String output = new String(Files.readAllBytes(report.toPath()));
+            return createIssuesFromOutput(output);
+        } else {
+            throw new IllegalArgumentException("File does not exist or could not be read!");
+        }
+    }
 
-		LOGGER.debug("Paging remainder: {}", remainder);
+    private List<DartAnalyzerReportIssue> createIssuesFromOutput(String output) {
+        Set<DartAnalyzerReportIssue> issues = new HashSet<>(new DartAnalyzerReportParser().parse(output));
+        LOGGER.debug("Found issues: {}", issues.size());
+        return new ArrayList<>(issues);
+    }
 
-		return remainder;
-	}
+    private List<String> getPaginatedFilesPaths(List<String> filesWithAbsolutePath) {
+        List<String> paginated = new ArrayList<String>();
 
-	private Integer getPaginationTotalPages(List<String> filesWithAbsolutePath, final Integer PAGE_SIZE,
-			Integer remainder) {
-		Integer total = filesWithAbsolutePath.size() / PAGE_SIZE;
+        LOGGER.debug("Paging the files to execute the analyzer...");
 
-		if (remainder != 0) {
-			total++;
-		}
-		LOGGER.debug("Paging total items: {}", total);
-		return total;
-	}
+        Integer pagingStart = 0;
+        Integer pagingRemainder = getPaginationRemainder(filesWithAbsolutePath);
+        Integer totalPages = getPaginationTotalPages(filesWithAbsolutePath, PAGE_SIZE, pagingRemainder);
 
-	private List<String> getFilesWithAbsolutePath(SensorContext sensorContext) {
-		List<String> filesWithAbsolutePath = new ArrayList<>();
+        for (int i = 0; i < totalPages; i++) {
+            LOGGER.debug("Current index: {}", i);
 
-		FileSystem fileSystem = getFileSystem(sensorContext);
+            LOGGER.debug("Current paging start: {}", pagingStart);
 
-		FilePredicate mainFilePredicate = getFilesFilter(fileSystem);
+            Integer pagingEnd = getPagingEnd(pagingStart, pagingRemainder, totalPages, i);
 
-		String absolutePath = fileSystem.baseDir().getAbsolutePath();
+            paginated.add(getFilesPathsSplitBySpace(filesWithAbsolutePath, pagingStart, pagingEnd));
 
-		LOGGER.debug("Files absolute path: {}", absolutePath);
+            pagingStart += PAGE_SIZE;
+        }
+        return paginated;
+    }
 
-		fileSystem.inputFiles(mainFilePredicate).forEach(s -> {
-			LOGGER.debug("Input file path: {}", s.toString());
+    private Integer getPagingEnd(Integer pagingStart, Integer pagingRemainder, Integer totalPages, int i) {
+        Integer pagingEnd = pagingStart + PAGE_SIZE;
+        if (isLastPage(pagingRemainder, totalPages, i)) {
+            pagingEnd = pagingStart + pagingRemainder;
+        }
+        LOGGER.debug("Current paging end: {}", pagingEnd);
+        return pagingEnd;
+    }
 
-			String fullPath = new StringBuilder(absolutePath).append(File.separator).append(s.toString().replace("/", File.separator))
-					.toString();
+    private String getFilesPathsSplitBySpace(List<String> filesWithAbsolutePath, Integer pagingStart,
+                                             Integer pagingEnd) {
+        return filesWithAbsolutePath.subList(pagingStart, pagingEnd).stream().collect(Collectors.joining(" "));
+    }
 
-			LOGGER.debug("Current file full path: {}", fullPath);
+    private boolean isLastPage(Integer pagingRemainder, Integer totalPages, int i) {
+        return pagingRemainder != 0 && i + 1 == totalPages;
+    }
 
-			filesWithAbsolutePath.add(fullPath);
-		});
+    private Integer getPaginationRemainder(List<String> filesWithAbsolutePath) {
+        Integer remainder = filesWithAbsolutePath.size() % PAGE_SIZE;
 
-		return filesWithAbsolutePath;
-	}
+        LOGGER.debug("Paging remainder: {}", remainder);
 
-	private FilePredicate getFilesFilter(FileSystem fileSystem) {
-		FilePredicate mainFilePredicate = fileSystem.predicates().and(
-				fileSystem.predicates().hasType(InputFile.Type.MAIN), fileSystem.predicates().hasLanguage(Dart.KEY));
-		return mainFilePredicate;
-	}
+        return remainder;
+    }
 
-	private FileSystem getFileSystem(SensorContext sensorContext) {
-		FileSystem fileSystem = sensorContext.fileSystem();
-		return fileSystem;
-	}
+    private Integer getPaginationTotalPages(List<String> filesWithAbsolutePath, final Integer PAGE_SIZE,
+                                            Integer remainder) {
+        Integer total = filesWithAbsolutePath.size() / PAGE_SIZE;
 
-	private void recordIssues(SensorContext sensorContext, List<DartAnalyzerReportIssue> issues) {
-		// Record issues
-		issues.forEach(i -> {
-			File file = new File(sensorContext.fileSystem().baseDir(), i.getFilePath());
-			LOGGER.debug("Inside issue forEach, file absolute path: {}", file.getAbsolutePath());
+        if (remainder != 0) {
+            total++;
+        }
+        LOGGER.debug("Paging total items: {}", total);
+        return total;
+    }
 
-			FilePredicate fp = sensorContext.fileSystem().predicates().hasAbsolutePath(file.getAbsolutePath());
-			if (!sensorContext.fileSystem().hasFiles(fp)) {
-				LOGGER.warn("File not included in SonarQube {}", file.getAbsoluteFile());
-			} else {
-				InputFile inputFile = sensorContext.fileSystem().inputFile(fp);
-				NewIssueLocation nil = new DefaultIssueLocation().on(inputFile)
-						.at(inputFile.selectLine(i.getLineNumber())).message(i.getMessage());
-				sensorContext.newIssue().forRule(RuleKey.of(DartAnalyzerRulesDefinition.REPOSITORY_KEY, i.getRuleId()))
-						.at(nil).save();
-			}
-		});
-	}
+    private List<String> getFilesWithAbsolutePath(SensorContext sensorContext) {
+        List<String> filesWithAbsolutePath = new ArrayList<>();
 
-	private void verifyIfDartAnalyzerExists() {
-		LOGGER.debug("Verify dart analyser...");
-		new ProcBuilder(ANALYZER_COMMAND).withArg("-h").run();
-		LOGGER.debug("Verify dart analyser done");
-	}
+        FileSystem fileSystem = getFileSystem(sensorContext);
 
-	private boolean existsAnalysisOptionsFile(SensorContext sensorContext) {
-		return new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME).exists();
-	}
+        FilePredicate mainFilePredicate = getFilesFilter(fileSystem);
 
-	private void saveCurrentAnalysisOptionsFile(SensorContext sensorContext) {
-		File analysisOptionsFile = new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME);
-		if (analysisOptionsFile.exists()) {
-			analysisOptionsFile
-					.renameTo(new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME + ".sonar"));
-			LOGGER.info("Backup of original analysis_options.yaml file to {}", ANALYSIS_OPTIONS_FILENAME + ".sonar");
-		}
-	}
+        String absolutePath = fileSystem.baseDir().getAbsolutePath();
 
-	private void createAnalysisOptionsFile(SensorContext sensorContext) throws IOException {
-		File analysisOptionsFile = new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME);
-		URL inputUrl = getClass().getResource(ANALYSIS_OPTIONS_FILE);
-		Resources.asByteSource(inputUrl).copyTo(Files.asByteSink(analysisOptionsFile));
-	}
+        LOGGER.debug("Files absolute path: {}", absolutePath);
 
-	private void restoreCurrentAnalysisOptionsFile(SensorContext sensorContext) {
-		File analysisOptionsFile = new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME);
-		File currentAnalysisOptionsFile = new File(sensorContext.fileSystem().baseDir(),
-				ANALYSIS_OPTIONS_FILENAME + ".sonar");
-		if (currentAnalysisOptionsFile.exists()) {
-			currentAnalysisOptionsFile.renameTo(analysisOptionsFile);
-			LOGGER.info("Restored original analysis_options.yaml file");
-		} else {
-			analysisOptionsFile.delete();
-		}
-	}
+        fileSystem.inputFiles(mainFilePredicate).forEach(s -> {
+            LOGGER.debug("Input file path: {}", s.toString());
+
+            String fullPath = new StringBuilder(absolutePath).append(File.separator).append(s.toString().replace("/", File.separator))
+                    .toString();
+
+            LOGGER.debug("Current file full path: {}", fullPath);
+
+            filesWithAbsolutePath.add(fullPath);
+        });
+
+        return filesWithAbsolutePath;
+    }
+
+    private FilePredicate getFilesFilter(FileSystem fileSystem) {
+        FilePredicate mainFilePredicate = fileSystem.predicates().and(
+                fileSystem.predicates().hasType(InputFile.Type.MAIN), fileSystem.predicates().hasLanguage(Dart.KEY));
+        return mainFilePredicate;
+    }
+
+    private FileSystem getFileSystem(SensorContext sensorContext) {
+        FileSystem fileSystem = sensorContext.fileSystem();
+        return fileSystem;
+    }
+
+    private void recordIssues(SensorContext sensorContext, List<DartAnalyzerReportIssue> issues) {
+        // Record issues
+        issues.forEach(i -> {
+            File file = new File(sensorContext.fileSystem().baseDir(), i.getFilePath());
+            LOGGER.debug("Inside issue forEach, file absolute path: {}", file.getAbsolutePath());
+
+            FilePredicate fp = sensorContext.fileSystem().predicates().hasAbsolutePath(file.getAbsolutePath());
+            if (!sensorContext.fileSystem().hasFiles(fp)) {
+                LOGGER.warn("File not included in SonarQube {}", file.getAbsoluteFile());
+            } else {
+                InputFile inputFile = sensorContext.fileSystem().inputFile(fp);
+                NewIssueLocation nil = new DefaultIssueLocation().on(inputFile)
+                        .at(inputFile.selectLine(i.getLineNumber())).message(i.getMessage());
+                sensorContext.newIssue().forRule(RuleKey.of(DartAnalyzerRulesDefinition.REPOSITORY_KEY, i.getRuleId()))
+                        .at(nil).save();
+            }
+        });
+    }
+
+    private void verifyIfDartAnalyzerExists() {
+        LOGGER.debug("Verify dart analyser...");
+        new ProcBuilder(ANALYZER_COMMAND).withArg("-h").run();
+        LOGGER.debug("Verify dart analyser done");
+    }
+
+    private boolean existsAnalysisOptionsFile(SensorContext sensorContext) {
+        return new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME).exists();
+    }
+
+    private void saveCurrentAnalysisOptionsFile(SensorContext sensorContext) {
+        File analysisOptionsFile = new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME);
+        if (analysisOptionsFile.exists()) {
+            analysisOptionsFile
+                    .renameTo(new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME + ".sonar"));
+            LOGGER.info("Backup of original analysis_options.yaml file to {}", ANALYSIS_OPTIONS_FILENAME + ".sonar");
+        }
+    }
+
+    private void createAnalysisOptionsFile(SensorContext sensorContext) throws IOException {
+        File analysisOptionsFile = new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME);
+        URL inputUrl = getClass().getResource(ANALYSIS_OPTIONS_FILE);
+        Resources.asByteSource(inputUrl).copyTo(com.google.common.io.Files.asByteSink(analysisOptionsFile));
+    }
+
+    private void restoreCurrentAnalysisOptionsFile(SensorContext sensorContext) {
+        File analysisOptionsFile = new File(sensorContext.fileSystem().baseDir(), ANALYSIS_OPTIONS_FILENAME);
+        File currentAnalysisOptionsFile = new File(sensorContext.fileSystem().baseDir(),
+                ANALYSIS_OPTIONS_FILENAME + ".sonar");
+        if (currentAnalysisOptionsFile.exists()) {
+            currentAnalysisOptionsFile.renameTo(analysisOptionsFile);
+            LOGGER.info("Restored original analysis_options.yaml file");
+        } else {
+            analysisOptionsFile.delete();
+        }
+    }
 }

--- a/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/FlutterPlugin.java
+++ b/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/FlutterPlugin.java
@@ -77,6 +77,15 @@ public class FlutterPlugin implements Plugin {
                         .defaultValue("false")
                         .build());
 
+        context.addExtension(
+                PropertyDefinition.builder(DartSensor.DART_ANALYSIS_USE_EXISTING_REPORT_PATH_KEY)
+                        .name("Use dartanalyzer report file for analysis")
+                        .description("Path to Dartanalyzer report file. If null, dartanalyzer will be executed. The path may be either absolute or relative to the project base directory. Run dartanalyzer with '--write PATH' to create the report.")
+                        .onQualifiers(Qualifiers.MODULE, Qualifiers.PROJECT)
+                        .category(DART_CATEGORY)
+                        .subCategory(ANALYSIS_SUBCATEGORY)
+                        .build());
+
         // Tests
         context.addExtension(FlutterTestSensor.class);
 


### PR DESCRIPTION
I already have an existing analyzer report in the CI pipeline which is created with `dartanalyzer --write analysis-report.txt` and want to reuse this to save time.
