### PR TITLE
Fix Homepage and Issue Tracker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <name>Flutter SonarQube Plugin</name>
     <description>Enables analysis of Dart and Flutter projects into SonarQube.</description>
-    <url>https://github.com/insideapp-oss/sonar-flutter</url>
+    <url>https://github.com/insideapp-oss/sonar-flutter/tree/master</url>
 
     <modules>
         <module>sonar-flutter-plugin</module>
@@ -29,6 +29,10 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <issueManagement>
+        <url>https://github.com/insideapp-oss/sonar-flutter/issues</url>
+    </issueManagement>
 
     <developers>
         <developer>


### PR DESCRIPTION
Fix Homepage and Issue Tracker links of the Sonarqube Marketplace page

![Homepage](https://github.com/insideapp-oss/sonar-flutter/assets/34942703/9190cc56-9c23-4058-9542-e6f12cfa90da)
![IssueTracker](https://github.com/insideapp-oss/sonar-flutter/assets/34942703/327a61ef-691b-4d06-9439-e42c5fea6059)
