### PR TITLE
Bump snakeyaml and jackson-databind to latest versions

### DIFF
--- a/dart-lang/pom.xml
+++ b/dart-lang/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.28</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>com.vdurmont</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Previous versions had known vulenerabilities.
```
Vulnerabilities
NAME              INSTALLED  FIXED-IN  TYPE          VULNERABILITY        SEVERITY
jackson-databind  2.13.4     2.13.4.2  java-archive  GHSA-jjjh-jjxp-wpff  High
snakeyaml         1.28       1.31      java-archive  GHSA-hhhw-99gj-p3c3  Medium
snakeyaml         1.28       2.0       java-archive  GHSA-mjmj-j48q-9wg2  High
snakeyaml         1.28       1.32      java-archive  GHSA-w37g-rhq8-7m4j  Medium
snakeyaml         1.28       1.31      java-archive  GHSA-3mc7-4q67-w48m  High
snakeyaml         1.28       1.31      java-archive  GHSA-98wm-3w3q-mw94  Medium
snakeyaml         1.28       1.32      java-archive  GHSA-9w3m-gqgf-c4p9  Medium
snakeyaml         1.28       1.31      java-archive  GHSA-c4r9-r8fh-9vj2  Medium
```

All tests passing and tested with local sonarqube instance.