### PR TITLE
fix(Dart): dart language files not indexed with SonarQube 10.4+

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,10 +13,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 1.11
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
           check-latest: true
           cache: 'maven'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
         id: tag_name
 
       - name: Set up JDK 1.11
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
           check-latest: true
           cache: 'maven'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 #### Bug Fixes
 
 - [#177](https://github.com/insideapp-oss/sonar-flutter/issues/177) analyzer execution fails when errors detected.
+- [#212](https://github.com/insideapp-oss/sonar-flutter/issues/212) source file not indexed with SonarQube 10.4+
+- 
 
 ## 0.5.0
 

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/Dart.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/Dart.java
@@ -17,13 +17,22 @@
  */
 package fr.insideapp.sonarqube.dart.lang;
 
+import org.apache.commons.lang3.StringUtils;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.resources.AbstractLanguage;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class Dart extends AbstractLanguage {
     public static final String KEY = "dart";
     private final Configuration config;
+
+    public static final List<String> FILE_SUFFIXES = List.of(".dart");
+
+    public static final String FILE_SUFFIXES_KEY = "sonar.dart.file.suffixes";
 
     public Dart(Configuration config) {
         super(KEY, "Dart");
@@ -31,6 +40,11 @@ public class Dart extends AbstractLanguage {
     }
 
     public String[] getFileSuffixes() {
-        return new String[]{"dart"};
+        final List<String> providedFilesSuffixes = Arrays.stream(config.getStringArray(FILE_SUFFIXES_KEY))
+                .map(String::trim)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toList());
+        final List<String> filesSuffixes = providedFilesSuffixes.isEmpty() ? FILE_SUFFIXES : providedFilesSuffixes;
+        return filesSuffixes.toArray(new String[0]);
     }
 }

--- a/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/FlutterPlugin.java
+++ b/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/FlutterPlugin.java
@@ -39,15 +39,29 @@ public class FlutterPlugin implements Plugin {
     public static final String DART_CATEGORY = "Dart";
     public static final String FLUTTER_CATEGORY = "Flutter";
     public static final String ANALYSIS_SUBCATEGORY = "Analysis";
+
+    public static final String GENERAL_SUBCATEGORY = "General";
     public static final String TESTS_SUBCATEGORY = "Tests";
 
     public static final String FLUTTER_TESTS_REPORT_PATH_KEY = "sonar.flutter.tests.reportPath";
     public static final String FLUTTER_LCOV_REPORT_PATH_KEY = "sonar.flutter.coverage.reportPath";
 
+
     public void define(Context context) {
 
         // Language support
         context.addExtensions(Dart.class, DartSensor.class, DartProfile.class);
+
+        context.addExtension(
+                PropertyDefinition.builder(Dart.FILE_SUFFIXES_KEY)
+                        .name("File Suffixes")
+                        .description("List of suffixes of Dart files to analyze.")
+                        .multiValues(true)
+                        .category(DART_CATEGORY)
+                        .subCategory(GENERAL_SUBCATEGORY)
+                        .onQualifiers(Qualifiers.PROJECT)
+                        .defaultValue(String.join(",", Dart.FILE_SUFFIXES))
+                        .build());
 
         // Add pubspec support
         context.addExtension(PubSpecSensor.class);

--- a/sonar-flutter-plugin/src/test/java/fr/insideapp/sonarqube/flutter/FlutterPluginTest.java
+++ b/sonar-flutter-plugin/src/test/java/fr/insideapp/sonarqube/flutter/FlutterPluginTest.java
@@ -42,7 +42,7 @@ public class FlutterPluginTest {
         plugin.define(context);
 
         List<?> extensions = context.getExtensions();
-        assertThat(extensions).hasSize(14);
+        assertThat(extensions).hasSize(15);
 
 
     }


### PR DESCRIPTION
This PR fixes Dart file not indexed issue.
This issue appeared on SonarQube 10.4+, as the way of specifying language file suffixes changes in the API.