### PR TITLE
Make Plugin Compatible with SonarQube Community 25.3

### DIFF
--- a/dart-lang/pom.xml
+++ b/dart-lang/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sonar-flutter</artifactId>
         <groupId>fr.insideapp.sonarqube</groupId>
-        <version>0.5.2</version>
+        <version>0.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>fr.insideapp.sonarqube</groupId>
     <artifactId>sonar-flutter</artifactId>
-    <version>0.5.2</version>
+    <version>0.5.3</version>
 
     <packaging>pom</packaging>
 
@@ -58,7 +58,7 @@
         <jdk.min.version>1.9</jdk.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <sonar.version>7.9</sonar.version>
+        <sonar.version>11.3.0.2824</sonar.version>
 
         <assertj.version>3.5.2</assertj.version>
         <junit.version>4.13.1</junit.version>
@@ -81,7 +81,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonarsource.sonarqube</groupId>
+            <groupId>org.sonarsource.api.plugin</groupId>
             <artifactId>sonar-plugin-api</artifactId>
             <version>${sonar.version}</version>
             <scope>provided</scope>
@@ -149,8 +149,14 @@
         <dependency>
             <groupId>org.sonarsource.sonarqube</groupId>
             <artifactId>sonar-testing-harness</artifactId>
-            <version>${sonar.version}</version>
+            <version>25.3.0.104237</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonarsource.sonarqube</groupId>
+            <artifactId>sonar-plugin-api-impl</artifactId>
+            <version>25.3.0.104237</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/sonar-flutter-plugin/pom.xml
+++ b/sonar-flutter-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sonar-flutter</artifactId>
         <groupId>fr.insideapp.sonarqube</groupId>
-        <version>0.5.2</version>
+        <version>0.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>fr.insideapp.sonarqube</groupId>
             <artifactId>dart-lang</artifactId>
-            <version>0.5.2</version>
+            <version>0.5.3</version>
         </dependency>
 
     </dependencies>

--- a/sonar-flutter-plugin/src/test/java/fr/insideapp/sonarqube/flutter/FlutterPluginTest.java
+++ b/sonar-flutter-plugin/src/test/java/fr/insideapp/sonarqube/flutter/FlutterPluginTest.java
@@ -34,7 +34,7 @@ public class FlutterPluginTest {
     @Test
     public void define() {
 
-        SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+        SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(25, 3), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
         Plugin.Context context = new Plugin.Context(sonarRuntime);
 
 


### PR DESCRIPTION
This PR updates the plugin to be compatible with the latest `SonarQube Community Edition (25.3.0.104237)` and `Sonar Server (2025.2.0.105476)`.

- Updated the `sonar-plugin-api` dependency to version `11.3.0.2824` and switched its package from `org.sonarsource.sonarqube` to `org.sonarsource.api.plugin` as it has been relocated in [Maven](https://mvnrepository.com/artifact/org.sonarsource.sonarqube/sonar-plugin-api).
- Added a new dependency on `sonar-plugin-api-impl`, since `SonarRuntimeImpl` has been moved there from `sonar-plugin-api 8.X`.