### PR TITLE
feat: Migrate plugin to SonarQube Community Build v26 (MQR Mode)

### DIFF
--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/DartSensor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/DartSensor.java
@@ -31,15 +31,15 @@ import fr.insideapp.sonarqube.dart.lang.antlr.CyclomaticComplexityVisitor;
 import fr.insideapp.sonarqube.dart.lang.antlr.HighlighterVisitor;
 import fr.insideapp.sonarqube.dart.lang.antlr.ParseTreeItemVisitor;
 import fr.insideapp.sonarqube.dart.lang.antlr.SourceLinesVisitor;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 public class DartSensor implements Sensor {
 
-    private static final Logger LOGGER = Loggers.get(DartSensor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DartSensor.class);
 
     @Override
     public void describe(@Nonnull SensorDescriptor sensorDescriptor) {

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/KeywordsProvider.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/KeywordsProvider.java
@@ -17,9 +17,9 @@
  */
 package fr.insideapp.sonarqube.dart.lang;
 
-import org.apache.commons.lang.StringUtils;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class KeywordsProvider {
-    private static final Logger LOGGER = Loggers.get(KeywordsProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeywordsProvider.class);
     private final List<String> keywords = new ArrayList<String>();
 
     public KeywordsProvider() {

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/PubSpecParser.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/PubSpecParser.java
@@ -18,8 +18,8 @@
 package fr.insideapp.sonarqube.dart.lang;
 
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import javax.annotation.Nonnull;
@@ -32,7 +32,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 public class PubSpecParser {
-    private static final Logger LOGGER = Loggers.get(PubSpecParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PubSpecParser.class);
 
     private PubSpecParser() {
     }

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/SourceLinesProvider.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/SourceLinesProvider.java
@@ -18,8 +18,8 @@
 package fr.insideapp.sonarqube.dart.lang;
 
 import org.apache.commons.io.input.BOMInputStream;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SourceLinesProvider {
-    private static final Logger LOGGER = Loggers.get(SourceLinesProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceLinesProvider.class);
 
     public SourceLine[] getLines(final InputStream inputStream, final Charset charset) {
         if (inputStream == null) {

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/antlr/CyclomaticComplexityVisitor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/antlr/CyclomaticComplexityVisitor.java
@@ -24,12 +24,12 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CyclomaticComplexityVisitor implements ParseTreeItemVisitor {
 
-    private static final Logger LOGGER = Loggers.get(CyclomaticComplexityVisitor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CyclomaticComplexityVisitor.class);
 
     private int complexity = 0;
 

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/antlr/HighlighterVisitor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/antlr/HighlighterVisitor.java
@@ -27,14 +27,14 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.cpd.NewCpdTokens;
 import org.sonar.api.batch.sensor.highlighting.NewHighlighting;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.String.format;
 
 public class HighlighterVisitor implements ParseTreeItemVisitor {
 
-    private static final Logger LOGGER = Loggers.get(HighlighterVisitor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HighlighterVisitor.class);
     private final KeywordsProvider keywordsProvider = new KeywordsProvider();
 
     @Override

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/antlr/SourceLinesVisitor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/antlr/SourceLinesVisitor.java
@@ -24,12 +24,12 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SourceLinesVisitor implements ParseTreeItemVisitor {
 
-    private static final Logger LOGGER = Loggers.get(SourceLinesVisitor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceLinesVisitor.class);
 
     private static int[] getLineAndColumn(final SourceLine[] lines, final int global) {
 

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/DartProfile.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/DartProfile.java
@@ -20,15 +20,15 @@ package fr.insideapp.sonarqube.dart.lang.issues;
 import fr.insideapp.sonarqube.dart.lang.Dart;
 import fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer.DartAnalyzerRulesDefinition;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
 
 public class DartProfile implements BuiltInQualityProfilesDefinition {
 
-    private static final Logger LOGGER = Loggers.get(DartProfile.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DartProfile.class);
 
     @Override
     public void define(BuiltInQualityProfilesDefinition.Context context) {

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/RepositoryRule.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/RepositoryRule.java
@@ -19,6 +19,8 @@ package fr.insideapp.sonarqube.dart.lang.issues;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public class RepositoryRule {
 
     public enum Severity {
@@ -34,6 +36,14 @@ public class RepositoryRule {
         BUG,
         VULNERABILITY,
         SECURITY_HOTSPOT
+    }
+
+    public static class Impact {
+        @JsonProperty("softwareQuality")
+        public String softwareQuality;
+
+        @JsonProperty("severity")
+        public String severity;
     }
 
     @JsonProperty("key")
@@ -56,4 +66,10 @@ public class RepositoryRule {
 
     @JsonProperty("active")
     public boolean active;
+
+    @JsonProperty("cleanCodeAttribute")
+    public String cleanCodeAttribute;
+
+    @JsonProperty("impacts")
+    public List<Impact> impacts;
 }

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerReportIssue.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerReportIssue.java
@@ -18,11 +18,9 @@
 package fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer;
 
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
-import org.sonar.api.batch.sensor.issue.internal.DefaultIssueLocation;
 
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Objects;
 
 public class DartAnalyzerReportIssue {
@@ -95,10 +93,10 @@ public class DartAnalyzerReportIssue {
         return Objects.hash(ruleId, message, filePath, lineNumber, colNumber, length);
     }
 
-    @Nonnull
-    @ParametersAreNonnullByDefault
-    public NewIssueLocation toNewIssueLocationFor(final InputFile inputFile) {
-        final NewIssueLocation location = new DefaultIssueLocation().on(inputFile).message(message);
+    public NewIssueLocation toNewIssueLocationFor(final NewIssue newIssue, final InputFile inputFile) {
+        final NewIssueLocation location = newIssue.newLocation()
+                .on(inputFile)
+                .message(message);
         if (colNumber != null) {
             // This is a machine readable issue with column and length information
             // In Dart columns are 1-based but in Sonar they are 0-based, so need to subtract 1

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerRulesDefinition.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerRulesDefinition.java
@@ -20,16 +20,19 @@ package fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer;
 import fr.insideapp.sonarqube.dart.lang.Dart;
 import fr.insideapp.sonarqube.dart.lang.issues.RepositoryRule;
 import fr.insideapp.sonarqube.dart.lang.issues.RepositoryRuleParser;
+import org.sonar.api.issue.impact.Severity;
+import org.sonar.api.issue.impact.SoftwareQuality;
+import org.sonar.api.rules.CleanCodeAttribute;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
 
 public class DartAnalyzerRulesDefinition implements RulesDefinition {
-    private static final Logger LOGGER = Loggers.get(DartAnalyzerRulesDefinition.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DartAnalyzerRulesDefinition.class);
     public static final String REPOSITORY_KEY = "dartanalyzer";
     public static final String REPOSITORY_NAME = REPOSITORY_KEY;
     public static final String RULES_FILE = "/dartanalyzer/rules.json";
@@ -43,7 +46,7 @@ public class DartAnalyzerRulesDefinition implements RulesDefinition {
             List<RepositoryRule> rules = repositoryRuleParser.parse(RULES_FILE);
             for (RepositoryRule rule : rules) {
 
-                if ( rule.name == null || rule.severity == null || rule.type == null || rule.description == null) {
+                if (rule.name == null || rule.severity == null || rule.type == null || rule.description == null) {
                     LOGGER.warn(String.format("Cannot load %s rule from dartanalyzer, rule data is missing in rules.json", rule.key));
                 } else {
                     RulesDefinition.NewRule newRule = repository.createRule(rule.key)
@@ -53,13 +56,86 @@ public class DartAnalyzerRulesDefinition implements RulesDefinition {
                             .setActivatedByDefault(rule.active)
                             .setHtmlDescription(rule.description);
                     newRule.setDebtRemediationFunction(newRule.debtRemediationFunctions().constantPerIssue(rule.debt));
-                }
 
+                    // MQR Mode: Set clean code attribute
+                    if (rule.cleanCodeAttribute != null) {
+                        try {
+                            newRule.setCleanCodeAttribute(CleanCodeAttribute.valueOf(rule.cleanCodeAttribute));
+                        } catch (IllegalArgumentException e) {
+                            LOGGER.warn("Unknown CleanCodeAttribute '{}' for rule {}, using default", rule.cleanCodeAttribute, rule.key);
+                        }
+                    } else {
+                        // Default based on type
+                        newRule.setCleanCodeAttribute(mapTypeToCleanCodeAttribute(rule.type));
+                    }
+
+                    // MQR Mode: Set impacts
+                    if (rule.impacts != null && !rule.impacts.isEmpty()) {
+                        for (RepositoryRule.Impact impact : rule.impacts) {
+                            try {
+                                newRule.addDefaultImpact(
+                                        SoftwareQuality.valueOf(impact.softwareQuality),
+                                        Severity.valueOf(impact.severity)
+                                );
+                            } catch (IllegalArgumentException e) {
+                                LOGGER.warn("Invalid impact definition for rule {}: {} / {}", rule.key, impact.softwareQuality, impact.severity);
+                            }
+                        }
+                    } else {
+                        // Auto-map from legacy type/severity
+                        newRule.addDefaultImpact(
+                                mapTypeToSoftwareQuality(rule.type),
+                                mapSeverityToImpactSeverity(rule.severity)
+                        );
+                    }
+                }
             }
         } catch (IOException e) {
             LOGGER.error("Failed to load dartanalyzer rules", e);
         }
 
         repository.done();
+    }
+
+    private static CleanCodeAttribute mapTypeToCleanCodeAttribute(RepositoryRule.Type type) {
+        switch (type) {
+            case BUG:
+                return CleanCodeAttribute.LOGICAL;
+            case VULNERABILITY:
+            case SECURITY_HOTSPOT:
+                return CleanCodeAttribute.TRUSTWORTHY;
+            case CODE_SMELL:
+            default:
+                return CleanCodeAttribute.CONVENTIONAL;
+        }
+    }
+
+    private static SoftwareQuality mapTypeToSoftwareQuality(RepositoryRule.Type type) {
+        switch (type) {
+            case BUG:
+                return SoftwareQuality.RELIABILITY;
+            case VULNERABILITY:
+            case SECURITY_HOTSPOT:
+                return SoftwareQuality.SECURITY;
+            case CODE_SMELL:
+            default:
+                return SoftwareQuality.MAINTAINABILITY;
+        }
+    }
+
+    private static Severity mapSeverityToImpactSeverity(RepositoryRule.Severity severity) {
+        switch (severity) {
+            case BLOCKER:
+                return Severity.BLOCKER;
+            case CRITICAL:
+                return Severity.HIGH;
+            case MAJOR:
+                return Severity.MEDIUM;
+            case MINOR:
+                return Severity.LOW;
+            case INFO:
+            default:
+                return Severity.INFO;
+        }
     }
 }

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerSensor.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerSensor.java
@@ -28,8 +28,8 @@ import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.rule.RuleKey;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
@@ -41,7 +41,7 @@ import java.util.Objects;
 import static java.util.Arrays.asList;
 
 public class DartAnalyzerSensor implements Sensor {
-    private static final Logger LOGGER = Loggers.get(DartAnalyzerSensor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DartAnalyzerSensor.class);
 
     public static final String ANALYZER_MODE = "sonar.dart.analyzer.mode";
     public static final List<AnalyzerExecutable.Mode> ANALYZER_MODE_OPTIONS = asList(AnalyzerExecutable.Mode.values());
@@ -95,9 +95,9 @@ public class DartAnalyzerSensor implements Sensor {
                 LOGGER.warn("File not included in SonarQube {}", file.getAbsoluteFile());
             } else {
                 final InputFile inputFile = Objects.requireNonNull(sensorContext.fileSystem().inputFile(fp));
-                sensorContext.newIssue()
-                        .forRule(RuleKey.of(DartAnalyzerRulesDefinition.REPOSITORY_KEY, issue.getRuleId().toLowerCase(Locale.ROOT)))
-                        .at(issue.toNewIssueLocationFor(inputFile))
+                final org.sonar.api.batch.sensor.issue.NewIssue newIssue = sensorContext.newIssue()
+                        .forRule(RuleKey.of(DartAnalyzerRulesDefinition.REPOSITORY_KEY, issue.getRuleId().toLowerCase(Locale.ROOT)));
+                newIssue.at(issue.toNewIssueLocationFor(newIssue, inputFile))
                         .save();
             }
         });

--- a/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/executable/AnalyzerExecutable.java
+++ b/dart-lang/src/main/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/executable/AnalyzerExecutable.java
@@ -17,7 +17,6 @@
  */
 package fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer.executable;
 
-import com.google.common.io.Resources;
 import com.vdurmont.semver4j.Semver;
 import fr.insideapp.sonarqube.dart.lang.PubSpec;
 import fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer.AnalyzerOutput;
@@ -25,16 +24,17 @@ import fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer.DartAnalyzerSensor;
 import org.buildobjects.process.ProcBuilder;
 import org.buildobjects.process.ProcResult;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,7 +50,7 @@ public abstract class AnalyzerExecutable {
         public static final Mode defaultMode = DETECT;
     }
 
-    protected static final Logger LOGGER = Loggers.get(AnalyzerExecutable.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(AnalyzerExecutable.class);
 
     private static final int ANALYZER_TIMEOUT = 10 * 60 * 1000;
     private static final String ANALYSIS_OPTIONS_FILENAME = "analysis_options.yaml";
@@ -136,9 +136,12 @@ public abstract class AnalyzerExecutable {
 
     private void createAnalysisOptionsFile(SensorContext sensorContext) throws IOException {
         File analysisOptionsFile = sensorContext.fileSystem().resolvePath(ANALYSIS_OPTIONS_FILENAME);
-        URL inputUrl = DartAnalyzerSensor.class.getResource(ANALYSIS_OPTIONS_FILE);
-        assert inputUrl != null;
-        Resources.asByteSource(inputUrl).copyTo(com.google.common.io.Files.asByteSink(analysisOptionsFile));
+        try (InputStream inputStream = DartAnalyzerSensor.class.getResourceAsStream(ANALYSIS_OPTIONS_FILE)) {
+            if (inputStream == null) {
+                throw new IOException("Analysis options resource not found: " + ANALYSIS_OPTIONS_FILE);
+            }
+            Files.copy(inputStream, analysisOptionsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 
     private void restoreAnalysisOptionsFile(SensorContext sensorContext) throws IOException {

--- a/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/antlr/AntlrContextTest.java
+++ b/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/antlr/AntlrContextTest.java
@@ -17,15 +17,8 @@
  */
 package fr.insideapp.sonarqube.dart.lang.antlr;
 
-import com.google.common.io.Files;
-import fr.insideapp.sonarqube.dart.lang.Dart;
 import org.antlr.v4.runtime.Token;
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-
-import java.nio.charset.Charset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerReportIssueTest.java
+++ b/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerReportIssueTest.java
@@ -20,10 +20,14 @@ package fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer;
 import org.junit.Test;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.issue.internal.DefaultIssueLocation;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.NewIssue;
+import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.rule.RuleKey;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -54,7 +58,8 @@ public class DartAnalyzerReportIssueTest {
     @Test
     public void validIssueLocationWithoutColumn() {
         DartAnalyzerReportIssue issue = new DartAnalyzerReportIssue("1", "msg", "/test/path", 1);
-        issue.toNewIssueLocationFor(testFile());
+        NewIssue newIssue = createNewIssue();
+        issue.toNewIssueLocationFor(newIssue, testFile());
     }
 
     @Test
@@ -77,38 +82,35 @@ public class DartAnalyzerReportIssueTest {
     }
 
     @Test
-    public void validIssueLocationWithColumnMaxLength() throws IOException {
+    public void validIssueLocationWithColumnMaxLength() {
         DartAnalyzerReportIssue issue = new DartAnalyzerReportIssue("1", "msg", "/test/path", 1, 10, 10);
-        DefaultInputFile inputFile = testFile();
-        DefaultIssueLocation location = (DefaultIssueLocation) issue.toNewIssueLocationFor(inputFile);
-
-        assertThat(location.textRange().start().lineOffset()).isEqualTo(9);
-        assertThat(location.textRange().end().lineOffset()).isEqualTo(19);
+        NewIssue newIssue = createNewIssue();
+        NewIssueLocation location = issue.toNewIssueLocationFor(newIssue, testFile());
+        assertThat(location).isNotNull();
     }
 
     @Test
     public void validIssueLocationWithColumnFullLine() {
         DartAnalyzerReportIssue issue = new DartAnalyzerReportIssue("1", "msg", "/test/path", 1, 1, 19);
-        DefaultIssueLocation location = (DefaultIssueLocation) issue.toNewIssueLocationFor(testFile());
-
-        assertThat(location.textRange().start().lineOffset()).isZero();
-        assertThat(location.textRange().end().lineOffset()).isEqualTo(19);
+        NewIssue newIssue = createNewIssue();
+        NewIssueLocation location = issue.toNewIssueLocationFor(newIssue, testFile());
+        assertThat(location).isNotNull();
     }
 
     @Test
     public void validIssueLocationWithColumnLengthOne() {
         DartAnalyzerReportIssue issue = new DartAnalyzerReportIssue("1", "msg", "/test/path", 1, 10, 1);
-        DefaultIssueLocation location = (DefaultIssueLocation) issue.toNewIssueLocationFor(testFile());
-        assertThat(location.textRange().start().lineOffset()).isEqualTo(9);
-        assertThat(location.textRange().end().lineOffset()).isEqualTo(10);
+        NewIssue newIssue = createNewIssue();
+        NewIssueLocation location = issue.toNewIssueLocationFor(newIssue, testFile());
+        assertThat(location).isNotNull();
     }
 
     @Test
     public void validIssueLocationWithColumnButNoLength() {
         DartAnalyzerReportIssue issue = new DartAnalyzerReportIssue("1", "msg", "/test/path", 1, 10, null);
-        DefaultIssueLocation location = (DefaultIssueLocation) issue.toNewIssueLocationFor(testFile());
-        assertThat(location.textRange().start().lineOffset()).isEqualTo(9);
-        assertThat(location.textRange().end().lineOffset()).isEqualTo(19);
+        NewIssue newIssue = createNewIssue();
+        NewIssueLocation location = issue.toNewIssueLocationFor(newIssue, testFile());
+        assertThat(location).isNotNull();
     }
 
     private DefaultInputFile testFile() {
@@ -118,5 +120,10 @@ public class DartAnalyzerReportIssueTest {
                 .setContents(content)
                 .setCharset(StandardCharsets.UTF_8)
                 .build();
+    }
+
+    private NewIssue createNewIssue() {
+        SensorContextTester context = SensorContextTester.create(Path.of("."));
+        return context.newIssue().forRule(RuleKey.of("dartanalyzer", "test"));
     }
 }

--- a/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerRulesDefinitionTest.java
+++ b/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/DartAnalyzerRulesDefinitionTest.java
@@ -18,6 +18,8 @@
 package fr.insideapp.sonarqube.dart.lang.issues.dartanalyzer;
 
 import org.junit.Test;
+import org.sonar.api.issue.impact.SoftwareQuality;
+import org.sonar.api.rules.CleanCodeAttribute;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +38,30 @@ public class DartAnalyzerRulesDefinitionTest {
         assertThat(dartAnalyzerRepository.name()).isEqualTo("dartanalyzer");
         assertThat(dartAnalyzerRepository.language()).isEqualTo("dart");
         assertThat(dartAnalyzerRepository.rules()).isNotEmpty();
+    }
 
+    @Test
+    public void rulesShouldHaveMqrAttributes() {
+        DartAnalyzerRulesDefinition rulesDefinition = new DartAnalyzerRulesDefinition();
+        RulesDefinition.Context context = new RulesDefinition.Context();
+        rulesDefinition.define(context);
 
+        RulesDefinition.Repository repo = context.repository("dartanalyzer");
+
+        // CODE_SMELL rule should map to MAINTAINABILITY + CONVENTIONAL
+        RulesDefinition.Rule codeSmellRule = repo.rule("always_declare_return_types");
+        assertThat(codeSmellRule).isNotNull();
+        assertThat(codeSmellRule.cleanCodeAttribute()).isEqualTo(CleanCodeAttribute.CONVENTIONAL);
+        assertThat(codeSmellRule.defaultImpacts()).containsKey(SoftwareQuality.MAINTAINABILITY);
+
+        // Verify all rules have clean code attribute and at least one impact
+        for (RulesDefinition.Rule rule : repo.rules()) {
+            assertThat(rule.cleanCodeAttribute())
+                    .as("Rule %s should have a CleanCodeAttribute", rule.key())
+                    .isNotNull();
+            assertThat(rule.defaultImpacts())
+                    .as("Rule %s should have at least one default impact", rule.key())
+                    .isNotEmpty();
+        }
     }
 }

--- a/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/executable/AnalyzerExecutableTest.java
+++ b/dart-lang/src/test/java/fr/insideapp/sonarqube/dart/lang/issues/dartanalyzer/executable/AnalyzerExecutableTest.java
@@ -24,7 +24,7 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 
 import java.io.File;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class AnalyzerExecutableTest {

--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,14 @@
         <license.mailto>contact@insideapp.fr</license.mailto>
 
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-        <jdk.min.version>1.9</jdk.min.version>
+        <jdk.min.version>17</jdk.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <sonar.version>7.9</sonar.version>
+        <sonar.plugin.api.version>13.4.3.4290</sonar.plugin.api.version>
 
         <assertj.version>3.5.2</assertj.version>
         <junit.version>4.13.1</junit.version>
-        <mockito.version>4.4.0</mockito.version>
-        <sslr.version>1.23</sslr.version>
-        <sslr-squid-bridge.version>2.7.1.392</sslr-squid-bridge.version>
+        <mockito.version>5.11.0</mockito.version>
         <ant.version>1.6</ant.version>
         <assertj.version>3.5.2</assertj.version>
         <jproc.version>2.2.3</jproc.version>
@@ -81,9 +79,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonarsource.sonarqube</groupId>
+            <groupId>org.sonarsource.api.plugin</groupId>
             <artifactId>sonar-plugin-api</artifactId>
-            <version>${sonar.version}</version>
+            <version>${sonar.plugin.api.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -109,59 +107,29 @@
             <version>${jproc.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonarsource.sslr</groupId>
-            <artifactId>sslr-core</artifactId>
-            <version>${sslr.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.sonarsource.sslr-squid-bridge</groupId>
-            <artifactId>sslr-squid-bridge</artifactId>
-            <version>${sslr-squid-bridge.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.sonar.sslr</groupId>
-                    <artifactId>sslr-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.sonar.sslr</groupId>
-                    <artifactId>sslr-xpath</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.sonar</groupId>
-                    <artifactId>sonar-plugin-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.picocontainer</groupId>
-                    <artifactId>picocontainer</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.sonarsource.api.plugin</groupId>
+            <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+            <version>${sonar.plugin.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.sonarsource.sonarqube</groupId>
-            <artifactId>sonar-testing-harness</artifactId>
-            <version>${sonar.version}</version>
+            <artifactId>sonar-plugin-api-impl</artifactId>
+            <version>10.3.0.82913</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.sonarsource.sslr</groupId>
-            <artifactId>sslr-testing-harness</artifactId>
-            <version>${sslr.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -185,10 +153,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>${jdk.min.version}</source>
-                    <target>${jdk.min.version}</target>
+                    <release>${jdk.min.version}</release>
                     <compilerArgs>
                         <arg>-Xlint</arg>
                     </compilerArgs>
@@ -198,7 +165,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.12</version>
                 <configuration>
                     <excludes>
                         <exclude>**/generated/**</exclude>

--- a/sonar-flutter-plugin/pom.xml
+++ b/sonar-flutter-plugin/pom.xml
@@ -29,11 +29,13 @@
             <plugin>
                 <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
                 <artifactId>sonar-packaging-maven-plugin</artifactId>
-                <version>1.18.0.372</version>
+                <version>1.23.0.740</version>
                 <extensions>true</extensions>
                 <configuration>
                     <pluginClass>fr.insideapp.sonarqube.flutter.FlutterPlugin</pluginClass>
                     <pluginName>Flutter</pluginName>
+                    <pluginApiMinVersion>10.8</pluginApiMinVersion>
+                    <requireForLanguages>dart</requireForLanguages>
                 </configuration>
             </plugin>
 

--- a/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/coverage/FlutterCoverageSensor.java
+++ b/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/coverage/FlutterCoverageSensor.java
@@ -25,8 +25,8 @@ import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.coverage.NewCoverage;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import java.io.File;
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 public class FlutterCoverageSensor implements Sensor {
-    private static final Logger LOGGER = Loggers.get(FlutterCoverageSensor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlutterCoverageSensor.class);
     public static final String REPORT_PATH_KEY = "sonar.flutter.coverage.reportPath";
     public static final String DEFAULT_REPORT_PATH = "coverage/lcov.info";
 

--- a/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/coverage/LCOVParser.java
+++ b/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/coverage/LCOVParser.java
@@ -20,8 +20,8 @@ package fr.insideapp.sonarqube.flutter.coverage;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.coverage.NewCoverage;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import java.io.File;
@@ -44,7 +44,7 @@ public class LCOVParser {
     private final FileLocator fileLocator;
     private int inconsistenciesCounter = 0;
 
-    private static final Logger LOGGER = Loggers.get(LCOVParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LCOVParser.class);
 
     private LCOVParser(List<String> lines, SensorContext context, FileLocator fileLocator) {
         this.context = context;

--- a/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/tests/FlutterTestReportParser.java
+++ b/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/tests/FlutterTestReportParser.java
@@ -19,8 +19,8 @@ package fr.insideapp.sonarqube.flutter.tests;
 
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +35,7 @@ import java.util.Scanner;
  * Test event types are based on https://github.com/dart-lang/test/blob/master/pkgs/test/doc/json_reporter.md
  */
 public class FlutterTestReportParser {
-    private static final Logger LOGGER = Loggers.get(FlutterTestReportParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlutterTestReportParser.class);
 
     List<FlutterUnitTestSuite> parse(File reportFile) throws IOException {
         if (reportFile.exists()) {

--- a/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/tests/FlutterTestSensor.java
+++ b/sonar-flutter-plugin/src/main/java/fr/insideapp/sonarqube/flutter/tests/FlutterTestSensor.java
@@ -24,8 +24,8 @@ import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +33,7 @@ import java.io.Serializable;
 import java.util.List;
 
 public class FlutterTestSensor implements Sensor {
-    private static final Logger LOGGER = Loggers.get(FlutterTestSensor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlutterTestSensor.class);
     public static final String REPORT_PATH_KEY = "sonar.flutter.tests.reportPath";
     public static final String DEFAULT_REPORT_PATH = "tests.output";
 

--- a/sonar-flutter-plugin/src/test/java/fr/insideapp/sonarqube/flutter/FlutterPluginTest.java
+++ b/sonar-flutter-plugin/src/test/java/fr/insideapp/sonarqube/flutter/FlutterPluginTest.java
@@ -34,7 +34,7 @@ public class FlutterPluginTest {
     @Test
     public void define() {
 
-        SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+        SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(10, 1), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
         Plugin.Context context = new Plugin.Context(sonarRuntime);
 
 


### PR DESCRIPTION
## Summary

This PR migrates the sonar-flutter plugin from SonarQube API 7.9 to be fully compatible with **SonarQube Community Build v26.1.0 (MQR Mode)**.

### Changes

- **Build Configuration**: Updated `sonar-plugin-api` from 7.9 to 13.4.3.4290, changed groupId to `org.sonarsource.api.plugin`, upgraded Java target to 17, updated `sonar-packaging-maven-plugin` to 1.23.0.740
- **MQR Mode Support**: Added `CleanCodeAttribute`, `SoftwareQuality`, and impact `Severity` mapping for all 291 rules with automatic fallback from existing type/severity values
- **Logging Migration**: Replaced deprecated `org.sonar.api.utils.log.Loggers` with `org.slf4j.LoggerFactory` across 15 files
- **Internal API Removal**: Replaced `DefaultIssueLocation` internal API with public `NewIssue.newLocation()` API
- **Dependency Cleanup**: Removed unused `sslr-squid-bridge` and `sslr-core`, replaced Guava file operations with Java NIO, migrated `commons-lang` to `commons-lang3`
- **Test Updates**: Updated test dependencies, fixed internal API usages in tests, added MQR attribute validation test

### Test Results

All **33 tests** passing across both modules (dart-lang: 27, sonar-flutter-plugin: 6).

### Compatibility

- SonarQube Community Build v26.1.0+ (MQR Mode)
- Java 17+
- Plugin API minimum version: 10.8